### PR TITLE
use the Joi already required instead of getting it again

### DIFF
--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -259,7 +259,7 @@ function All() {
     this._inner.matches = [];
 }
 
-require('util').inherits(All, Object.getPrototypeOf(require('joi/lib/alternatives')).constructor);
+require('util').inherits(All, Object.getPrototypeOf(Joi.alternatives()).constructor);
 
 All.prototype._base = function (value, state, options) {
     var errors = [];


### PR DESCRIPTION
https://trello.com/c/uRTYARkF/159-3-as-a-360-product-owner-i-would-like-to-have-claim-entry-fields-validation-stored-on-the-server-so-that-we-can-replace-it-with-

The require of a specific Joi file was causing problems in Stu. The same function can be extracted from the Joi library already required without breaking tests
